### PR TITLE
it was possible to make tag's input field active only by clicking in the...

### DIFF
--- a/css/popup.css
+++ b/css/popup.css
@@ -757,6 +757,7 @@ label {
 }
 .extra-search li.es-input input {
   border-radius: 0;
+	width: 265px;
   min-width: 40px;
   max-width: 300px;
   display: block;


### PR DESCRIPTION
it was possible to make tag's input field active only by clicking in the area that has a text. Here is in the bottom the url with a screenshot with the area
http://prntscr.com/5elfn6
I've just set the width for the input.
